### PR TITLE
addCreatingIssueNote

### DIFF
--- a/src/content/docs/task-tracking/creating-issues.mdx
+++ b/src/content/docs/task-tracking/creating-issues.mdx
@@ -3,9 +3,9 @@ title: Creating issues
 description: Learn how to create an issue in your Huly workspace.
 ---
 
-import { Image } from 'astro:assets';
-import { YouTube } from 'astro-embed';
-import createIssue from '../../../assets/screenshots/create-issue.png';
+import { Image } from "astro:assets";
+import { YouTube } from "astro-embed";
+import createIssue from "../../../assets/screenshots/create-issue.png";
 
 ### What are issues?
 
@@ -19,12 +19,9 @@ Select the Tracker view by clicking the checkbox icon on the left sidebar, and e
 
 Click the blue `+ New issue` button at the stop of the side panel. This will open a dialog where you can enter some initial settings for your issue. After entering your desired settings, click `Create issue`.
 
-<Image 
-src={createIssue} 
-alt='Create issue' 
-inferSize
-quality='max'
-/>
+> **_Note:_** If you see Resume draft instead of + New issue then click on it - this is your task.
+
+<Image src={createIssue} alt="Create issue" inferSize quality="max" />
 
 ### Issue settings
 
@@ -32,11 +29,11 @@ When creating or editing an issue, you can configure the following settings:
 
 **Project**: In the top left corner of the dialog, you will see the project that this issue is associated with. Click on the name of the project to see a dropdown where you can choose to select a different project to associate with this issue.
 
-**Issue title**: A title for your issue.  
+**Issue title**: A title for your issue.
 
 **Description**: A description of your issue. Descriptions may be formatted with markdown formatting, including headers, codeblocks, links and more.
 
-**Issue status**: Setting the issue status to "Todo" (and adding an assignee) will automatically generate an [action item](../creating-action-items) in that member's Planner 
+**Issue status**: Setting the issue status to "Todo" (and adding an assignee) will automatically generate an [action item](../creating-action-items) in that member's Planner
 
 **Priority**: Choose from No priority, Low, Medium, High or Urgent.
 
@@ -64,4 +61,4 @@ There are so many ways to customize issues to suit the needs of your specific pr
 
 Check out our tutorial on task tracking in Huly for a step-by-step guide on creating issues, assigning action items and getting the most out of task automations.
 
-<YouTube id='ljpz0bZ75JA' posterQuality='max' />
+<YouTube id="ljpz0bZ75JA" posterQuality="max" />

--- a/src/content/docs/task-tracking/creating-issues.mdx
+++ b/src/content/docs/task-tracking/creating-issues.mdx
@@ -3,9 +3,9 @@ title: Creating issues
 description: Learn how to create an issue in your Huly workspace.
 ---
 
-import { Image } from "astro:assets";
-import { YouTube } from "astro-embed";
-import createIssue from "../../../assets/screenshots/create-issue.png";
+import { Image } from 'astro:assets';
+import { YouTube } from 'astro-embed';
+import createIssue from '../../../assets/screenshots/create-issue.png';
 
 ### What are issues?
 
@@ -19,9 +19,14 @@ Select the Tracker view by clicking the checkbox icon on the left sidebar, and e
 
 Click the blue `+ New issue` button at the stop of the side panel. This will open a dialog where you can enter some initial settings for your issue. After entering your desired settings, click `Create issue`.
 
-> **_Note:_** If you see Resume draft instead of + New issue then click on it - this is your task.
+> **_Note:_** If you navigate away while creating an issue, you'll notice that the `+ New issue` button becomes `+ Resume draft`. Click this to re-open the issue you were working on.
 
-<Image src={createIssue} alt="Create issue" inferSize quality="max" />
+<Image 
+    src={createIssue} 
+    alt="Create issue" 
+    inferSize 
+    quality="max" 
+/>
 
 ### Issue settings
 
@@ -61,4 +66,4 @@ There are so many ways to customize issues to suit the needs of your specific pr
 
 Check out our tutorial on task tracking in Huly for a step-by-step guide on creating issues, assigning action items and getting the most out of task automations.
 
-<YouTube id="ljpz0bZ75JA" posterQuality="max" />
+<YouTube id='ljpz0bZ75JA' posterQuality='max' />


### PR DESCRIPTION
I used your platform for the first time and wanted to do everything myself at first, but then I went to the documentation and started doing everything according to it, a problem appeared that I want to prevent subsequent users from experiencing.
Problem: when you cancel the creation of an issue via ESC, the `+ New Issue` button is replaced by `Resume Draft`, since one button is responsible for several actions, I had a desonation and for some time I could not understand where the ` button was + New issue`.

I might also add a few words about the `import` function. I didn’t find anything in the documentation about it and tried to figure out how it works on my own, unfortunately I didn’t understand it. But I would be happy to supplement the documentation about its functionality.