### PR TITLE
New documentation for Cards, improved organization & small fixes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -55,20 +55,11 @@ export default defineConfig({
             label: "Cards",
             collapsed: false,
             items: [
-              {
-                label: "Introduction to Cards",
-                link: "/cards/cards-overview/",
-              },
-              {
-                label: "Cards",
-                collapsed: false,
-                items: [
-                  {label: 'Creating Cards', link: '/cards/cards/creating-cards/'},
-                  {label: 'Parent-child Cards', link: '/cards/cards/parent-child-cards/'},     
-                  {label: 'View, sort and filter Cards', link: '/cards/cards/view-sort-filter-cards/'},
-                  {label: 'Cards vs. Documents', link: '/cards/cards/cards-vs-documents/'},     
-                ]
-              },
+              {label: "Introduction to Cards", link: "/cards/cards-overview/"},
+              {label: 'Creating Cards', link: '/cards/creating-cards/'},
+              {label: 'Parent-child Cards', link: '/cards/parent-child-cards/'},     
+              {label: 'View, sort and filter Cards', link: '/cards/view-sort-filter-cards/'},
+              {label: 'Cards vs. Documents', link: '/cards/cards-vs-documents/'},     
               {
                 label: "Types",
                 collapsed: false,

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -65,7 +65,8 @@ export default defineConfig({
                 items: [
                   {label: 'Creating Cards', link: '/cards/cards/creating-cards/'},
                   {label: 'Parent-child Cards', link: '/cards/cards/parent-child-cards/'},     
-                  {label: 'View, sort and filter Cards', link: '/cards/cards/view-sort-filter-cards/'},     
+                  {label: 'View, sort and filter Cards', link: '/cards/cards/view-sort-filter-cards/'},
+                  {label: 'Cards vs. Documents', link: '/cards/cards/cards-vs-documents/'},     
                 ]
               },
               {

--- a/src/content/docs/cards/cards-overview.mdx
+++ b/src/content/docs/cards/cards-overview.mdx
@@ -23,7 +23,7 @@ The following elements make up the Cards system. Click on any guide to learn mor
 
 * [**Types**](/cards/types/types-overview) define the structure of information within the system. You can think of a Type like a blueprint with specific instructions for what details you'll need to store for each piece of information. 
 * [**Tags**](/cards/tags/tags-overview) are used to add additional properties or behaviors to a Type. Tags allow you to define a specific set of properties that can be applied to multiple Types.
-* [**Cards**](/cards/cards/creating-cards) are "instances" of a Type — the real information that you're storing in your knowledge management system. Each Card is a unique piece of information that follows the structure defined by its Type.
+* [**Cards**](/cards/creating-cards) are "instances" of a Type — the real information that you're storing in your knowledge management system. Each Card is a unique piece of information that follows the structure defined by its Type.
 * [**Relations**](/cards/relations/relations-overview) define the connections between different Types and Tags, allowing you to link related information together with Cards.
 
 ## Using Cards for knowledge management

--- a/src/content/docs/cards/cards-vs-documents.mdx
+++ b/src/content/docs/cards/cards-vs-documents.mdx
@@ -3,7 +3,7 @@ title: Cards vs. Documents
 description: Learn when to use Cards and when to use Documents.
 ---
 
-You can use Cards to completely replace Documents in your workspace — or use them both simultaneously for different purposes. Let’s take a look at the key similarities and differences between Documents and Cards.
+You can use Cards to completely replace [Documents](/knowledge-management/documents) in your workspace — or use them both simultaneously for different purposes. Let’s take a look at the key similarities and differences between Documents and Cards.
 
 #### Similarities
 

--- a/src/content/docs/cards/cards/cards-vs-documents.mdx
+++ b/src/content/docs/cards/cards/cards-vs-documents.mdx
@@ -1,0 +1,46 @@
+---
+title: Cards vs. Documents
+description: Learn when to use Cards and when to use Documents.
+---
+
+You can use Cards to completely replace Documents in your workspace — or use them both simultaneously for different purposes. Let’s take a look at the key similarities and differences between Documents and Cards.
+
+#### Similarities
+
+- Content is created with the same text editor  
+- Activity section records change history and includes area for commenting  
+- Set roles, permissions and privacy at the space level  
+
+#### Differences
+
+There are a few important differences between Cards and Documents, which are summarized in the table below:
+
+| **Feature**                  | **Documents**                                                                 | **Cards**                                                                                      |
+|--------------------------|---------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| **Attributes**           | Attributes are defined by the system (title, content, created by, etc.) and cannot be changed | In addition to the default attributes defined by the system, you can also define as many **custom attributes** as you want                         |
+| **Sorting and filtering**| Cannot be sorted or filtered by attributes                                   | Can be sorted and filtered by attributes                                                       |
+| **Attachments**          | No designated area for file attachments (you can only send attachments with a comment in the Activity section) | Designated area for attachments                                                      |
+| **Organizational structure** | Nested, where documents can be nested within other documents            | Organized by Type, where Cards of the same Type are grouped together                      |
+| **Relations**            | Can be linked together in a 1:1 relation through @ mentions and backlinks | Can be linked through parent-child relations, and using References and Relations defined on their Type |
+
+> **Note:** While our initial implementation of Cards is focused on knowledge management, Cards will also serve as the foundation for many other features on the platform, including process management and threads. With Cards, you'll be able to build your own custom applications within Huly, such as a CRM, CMS, project management system and more. Stay tuned for more updates soon!
+
+---
+
+#### Okay, that was a lot of information … so which should I choose?
+
+Let’s keep it simple!
+
+##### Use **Cards** if:
+
+- You need to add custom attributes to your docs, like “client”, “document type” or “status”  
+- You need to be able to sort and filter your content by attributes  
+- You need to define specific _relations_ between types of entities; for example: `Contract ←→ Client`  
+- You plan to build processes and workflows around your Cards in the future  
+
+##### Use **Documents** if:
+
+- Your docs organization is simple, where the nested document structure is sufficient  
+- You need to jot down some quick notes, without needing to store them in a structured format  
+
+Of course, the best way to find out which system is right for you is to try them both and see what works. Happy exploring! 🚀

--- a/src/content/docs/cards/creating-cards.mdx
+++ b/src/content/docs/cards/creating-cards.mdx
@@ -4,8 +4,8 @@ description: Learn how to create Cards.
 ---
 
 import { Image } from "astro:assets";
-import cardExampleNPC from "../../../../assets/screenshots/huly/cards/card-example-npc.png";
-import cardsSpaces from "../../../../assets/screenshots/huly/cards/cards-spaces.png";
+import cardExampleNPC from "../../../assets/screenshots/huly/cards/card-example-npc.png";
+import cardsSpaces from "../../../assets/screenshots/huly/cards/cards-spaces.png";
 
 <div className="rounded-box">
   <h5><strong>What is a Card?</strong></h5>
@@ -26,7 +26,7 @@ To create a new space, click the `+ Create Space` button in the top left corner 
 
 <Image src={cardsSpaces} alt="Creating a Cards space" inferSize quality="max" />
 
-Spaces for Cards act like any other space in Huly, meaning you can leave, join and archive spaces, and global admin roles will apply. For more on managing permissions at the workspace and space level, see our guide on [Roles and Permissions](../../../advanced-settings/roles).
+Spaces for Cards act like any other space in Huly, meaning you can leave, join and archive spaces, and global admin roles will apply. For more on managing permissions at the workspace and space level, see our guide on [Roles and Permissions](../../advanced-settings/roles).
 
 ## Creating Cards
 
@@ -38,7 +38,7 @@ The following elements make up a Card:
 2. **Type** - the Type that defines the properties of your Card (see [Creating Types](/cards/types/creating-types))
 4. **Properties** - the details of your Card, as defined by the Type
 5. **Rich text editor** - a collaborative text editing area that supports markdown formatting, images, tables and more
-6. **Children** - an area for adding child Cards (see [Parent-child Cards](/cards/cards/parent-child-cards))
+6. **Children** - an area for adding child Cards (see [Parent-child Cards](/cards/parent-child-cards))
 7. **Attachments** - an area for uploading files
 8. **Activity** - a log of all changes made to the Card and area for commenting
 

--- a/src/content/docs/cards/parent-child-cards.mdx
+++ b/src/content/docs/cards/parent-child-cards.mdx
@@ -4,8 +4,8 @@ description: Learn how to create parent-child Cards and their use cases.
 ---
 
 import { Image } from "astro:assets";
-import parentChildCards from "../../../../assets/screenshots/huly/cards/parent-child-cards.png";
-import setParent from "../../../../assets/screenshots/huly/cards/set-parent.png";
+import parentChildCards from "../../../assets/screenshots/huly/cards/parent-child-cards.png";
+import setParent from "../../../assets/screenshots/huly/cards/set-parent.png";
 
 Cards can be connected through a parent-child relationship, where the child Card is best understood in the context of its parent Card. This is useful for creating a hierarchical structure of knowledge and information.
 

--- a/src/content/docs/cards/relations/relating-cards.mdx
+++ b/src/content/docs/cards/relations/relating-cards.mdx
@@ -28,4 +28,4 @@ To delete the Relation entirely, navigate back to Settings, open the Relation an
 
 ## Parent-child Cards
 
-In some cases you may want to connect parent-child Cards instead of using Relations. For more on this, see [Parent-child Cards](/cards/cards/parent-child-cards).
+In some cases you may want to connect parent-child Cards instead of using Relations. For more on this, see [Parent-child Cards](/cards/parent-child-cards).

--- a/src/content/docs/cards/relations/relations-overview.mdx
+++ b/src/content/docs/cards/relations/relations-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: What are Relatons?
+title: What are Relations?
 description: Learn about Relations in the Cards system.
 ---
 

--- a/src/content/docs/cards/tags/applying-tags.mdx
+++ b/src/content/docs/cards/tags/applying-tags.mdx
@@ -6,7 +6,7 @@ description: Learn how to apply Tags to Cards.
 import { Image } from "astro:assets";
 import tags from "../../../../assets/screenshots/huly/cards/tags.png";
 
-Now that we've learned about [Tags](/cards/tags/tags-overview) and how to [create](/cards/tags/creating-tags) them, let's explore how to apply them to our Cards. First, you'll need to create a Card from a Type that has Tags. If you haven't already, check out our guides on [creating Cards](/cards/cards/creating-cards).
+Now that we've learned about [Tags](/cards/tags/tags-overview) and how to [create](/cards/tags/creating-tags) them, let's explore how to apply them to our Cards. First, you'll need to create a Card from a Type that has Tags. If you haven't already, check out our guides on [creating Cards](/cards/creating-cards).
 
 ## Adding a Tag to a Card
 

--- a/src/content/docs/cards/types/creating-types.mdx
+++ b/src/content/docs/cards/types/creating-types.mdx
@@ -29,7 +29,7 @@ To add a property, click the `+` button in the properties section. Select from t
 
 In our example, we know that all Game Components will have a `Name` and `Description`, so we'll add these on the `Game Component` Type as `Text` properties.
 
-> **Note:** Properties can also be added directly to Cards — see [Creating Cards](/cards/cards/creating-cards).
+> **Note:** Properties can also be added directly to Cards — see [Creating Cards](/cards/creating-cards).
 
 ##### Creating dropdown menus (enums)
 

--- a/src/content/docs/cards/types/file-types.mdx
+++ b/src/content/docs/cards/types/file-types.mdx
@@ -48,7 +48,7 @@ In our **game design** example, we'll create two Types derived from `File` to ma
 
 ## Creating Cards from `File` Types
 
-Creating Cards from `File` Types is the same as creating Cards from any other Type (see our guide for [Creating Cards](/cards/cards/creating-cards)) — when you create a Card from a `File` Type, however, you'll see a designated area for uploading files.
+Creating Cards from `File` Types is the same as creating Cards from any other Type (see our guide for [Creating Cards](/cards/creating-cards)) — when you create a Card from a `File` Type, however, you'll see a designated area for uploading files.
 
 Here, you can click the upload button or drop your files into the upload area.
 
@@ -70,6 +70,6 @@ The `File` Type is a powerful tool for managing files in your Huly workspace. He
 ## Other ways to connect files to Cards
 In addition to using the `File` Type, there are several other ways to link files and media to Cards. There are advantages to each method, so choose the combination that works best for you!
 
-* **Card attachments** - Attach files to any Card, regardless of its Type, by adding them directly to the Card’s interface (see [Creating Cards](/cards/cards/creating-cards) for an example). This is a great way to quickly attach a file that doesn't need its own dedicated Card.
+* **Card attachments** - Attach files to any Card, regardless of its Type, by adding them directly to the Card’s interface (see [Creating Cards](/cards/creating-cards) for an example). This is a great way to quickly attach a file that doesn't need its own dedicated Card.
 * **Inline embeds** - Use the `/` shortcut in the collaborative editor to embed images directly within the content. This is useful for adding visual elements to text-based Cards.
 * **Comment attachments** - You can also attach files to specific comments within the activity section, which is handy when you need to send a resource or snapshot with your message.

--- a/src/content/docs/cards/view-sort-filter-cards.mdx
+++ b/src/content/docs/cards/view-sort-filter-cards.mdx
@@ -4,7 +4,7 @@ description: Learn how to manage Cards with sorting, search and filtered views.
 ---
 
 import { Image } from "astro:assets";
-import filterList from "../../../../assets/screenshots/huly/cards/filter-list.png";
+import filterList from "../../../assets/screenshots/huly/cards/filter-list.png";
 
 Viewing, sorting, and filtering Cards in the game design system allows you to manage complex, interrelated pieces of information more efficiently than plain documents in Huly. While documents are static and typically organized in a linear fashion, Cards offer a dynamic, flexible way to organize and access content based on various attributes, relationships, and tags. This approach enables you to quickly locate relevant information, prioritize tasks, and track connections Cards.
 

--- a/src/content/docs/getting-started/introduction-tracex.mdx
+++ b/src/content/docs/getting-started/introduction-tracex.mdx
@@ -17,27 +17,27 @@ This documentation covers eQMS features unique to TraceX. For more information, 
 
 In addition to the project management features available in Huly, TraceX includes the following unique eQMS features:
 
-* [Roles & permissions](../../eqms/roles)
-* [Products](../../eqms/products)
-* [Trainings](../../eqms/trainings)
+* [Roles & permissions](/eqms/roles)
+* [Products](/eqms/products)
+* [Trainings](/eqms/trainings)
 * Controlled document types
-    * [Templates](../../eqms/templates)
-    * [Quality documents](../../eqms/quality-documents)
-    * [Technical documentation](../../eqms/technical-documentation)
+    * [Templates](/eqms/templates)
+    * [Quality documents](/eqms/quality-documents)
+    * [Technical documentation](/eqms/technical-documentation)
 * Controlled document authoring
-    * [Editing & formatting](../../eqms/editing-formatting)
-    * [Additional settings](../../eqms/document-settings)
-    * [Document versions](../../eqms/document-versions)
-    * [Ownership & authorship](../../eqms/ownership-authorship)
-* [Reviewing and approving with electronic signatures](../../eqms/review-approval)
-* [Filtering documents](../../eqms/document-filtering)
+    * [Editing & formatting](/eqms/editing-formatting)
+    * [Additional settings](/eqms/document-settings)
+    * [Document versions](/eqms/document-versions)
+    * [Ownership & authorship](/eqms/ownership-authorship)
+* [Reviewing and approving with electronic signatures](/eqms/review-approval)
+* [Filtering documents](/eqms/document-filtering)
 
 TraceX also includes the following features and modules available in Huly:
 
-* [Task tracking](../../task-tracking/creating-issues)
-* [Chat](../../communication/sending-messages)
-* [Virtual office](../../communication/virtual-office) (including video conferencing)
-* [Documents](../../knowledge-management/documents)
+* [Task tracking](/task-tracking/creating-issues)
+* [Chat](/communication/sending-messages)
+* [Virtual office](/communication/virtual-office) (including video conferencing)
+* [Documents](/knowledge-management/documents)
 
 ## Getting started
 

--- a/src/content/docs/knowledge-management/documents.mdx
+++ b/src/content/docs/knowledge-management/documents.mdx
@@ -16,6 +16,8 @@ There are many uses for documents on the Huly platform, including sharing refere
 - [Collaborative editing](/knowledge-management/collaborative-editing)
 - [Action items in documents](/knowledge-management/documents-action-items)
 
+> **Note:** In many cases, you may find that using [Cards](/cards/cards-overview) is a better fit for your needs than using Documents. Cards are designed to be more structured and flexible, allowing you to create custom attributes, relations and tags. If you're not sure which system is right for you, check out our guide on [Cards vs. Documents](/cards/cards/cards-vs-documents).
+
 ## Creating a teamspace
 
 Documents are organized into teamspaces, which can be used to model your team's specific needs. For example, you may choose to organize your documents into teamspaces called "Features", "Marketing", "Style Guides" etc.

--- a/src/content/docs/knowledge-management/documents.mdx
+++ b/src/content/docs/knowledge-management/documents.mdx
@@ -16,7 +16,7 @@ There are many uses for documents on the Huly platform, including sharing refere
 - [Collaborative editing](/knowledge-management/collaborative-editing)
 - [Action items in documents](/knowledge-management/documents-action-items)
 
-> **Note:** In many cases, you may find that using [Cards](/cards/cards-overview) is a better fit for your needs than using Documents. Cards are designed to be more structured and flexible, allowing you to create custom attributes, relations and tags. If you're not sure which system is right for you, check out our guide on [Cards vs. Documents](/cards/cards/cards-vs-documents).
+> **Note:** In many cases, you may find that using [Cards](/cards/cards-overview) is a better fit for your needs than using Documents. Cards are designed to be more structured and flexible, allowing you to create custom attributes, relations and tags. If you're not sure which system is right for you, check out our guide on [Cards vs. Documents](/cards/cards-vs-documents).
 
 ## Creating a teamspace
 


### PR DESCRIPTION
Updates included in this PR:
1. Added the Cards vs. Documents doc, which outlines differences between these modules and use cases for each
2. Reorganized Cards docs — put all general docs at the top level of the hierarchy for Cards docs
3. Fixed link file paths — identified incorrect link paths in getting started guide; for example, changed `[Roles & permissions](../../eqms/roles)` to `[Roles & permissions](/eqms/roles)`